### PR TITLE
Implement Python DAP server launch in extension

### DIFF
--- a/ink-trace-extension/package.json
+++ b/ink-trace-extension/package.json
@@ -1,16 +1,15 @@
 {
   "name": "ink-trace-extension",
-  "displayName": "ink-trace-extension",
-  "description": "Debugger for smart contracts for ink!",
+  "displayName": "Ink Trace Debugger",
+  "description": "Debugger for ink! smart contracts",
   "version": "0.0.1",
   "engines": {
     "vscode": "^1.85.0"
   },
-  "categories": [
-    "Debuggers"
-  ],
+  "categories": ["Debuggers"],
   "activationEvents": [
-    "onDebug"
+    "onDebug",
+    "onCommand:ink-trace.startDebugging"
   ],
   "main": "./out/extension.js",
   "scripts": {
@@ -26,47 +25,67 @@
       {
         "type": "ink-trace",
         "label": "Ink Trace Debug",
-        "languages": [
-          "rust"
+        "program": "./out/extension.js",
+        "runtime": "node",
+        "configurationAttributes": {
+          "launch": {
+            "required": ["program"],
+            "properties": {
+              "program": {
+                "type": "string",
+                "description": "Path to compiled contract.wasm"
+              },
+              "stopOnEntry": {
+                "type": "boolean",
+                "default": true,
+                "description": "Break at the beginning of the contract"
+              },
+              "args": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Additional arguments for the contract"
+              }
+            }
+          }
+        },
+        "initialConfigurations": [
+          {
+            "type": "ink-trace",
+            "request": "launch",
+            "name": "Debug Ink Contract",
+            "program": "${file}",
+            "stopOnEntry": true,
+            "args": []
+          }
         ],
         "configurationSnippets": [
           {
-            "label": "Ink Trace: Launch",
-            "description": "Launch and debug a file with Ink Trace.",
+            "label": "Ink Trace: Launch Contract",
+            "description": "Debug an ink! smart contract",
             "body": {
               "type": "ink-trace",
               "request": "launch",
-              "name": "Ink Trace Launch",
+              "name": "Debug Ink Contract",
               "program": "${file}",
               "stopOnEntry": true
             }
           }
-        ],
-        "configurationAttributes": {
-          "launch": {
-            "required": [
-              "program"
-            ],
-            "properties": {
-              "program": {
-                "type": "string",
-                "description": "Absolute path to the program file to debug.",
-                "default": "${file}"
-              },
-              "stopOnEntry": {
-                "type": "boolean",
-                "description": "Automatically stop the debugger after launch.",
-                "default": true
-              }
-            }
-          }
-        }
+        ]
+      }
+    ],
+    "commands": [
+      {
+        "command": "ink-trace.startDebugging",
+        "title": "Start Ink! Debugging",
+        "category": "Ink! Trace"
       }
     ]
   },
   "devDependencies": {
     "@types/mocha": "^10.0.6",
-    "@types/node": "20.x",
+    "@types/node": "^20.19.2",
     "@types/vscode": "^1.85.0",
     "@typescript-eslint/eslint-plugin": "^7.11.0",
     "@typescript-eslint/parser": "^7.11.0",

--- a/ink-trace-extension/src/extension.ts
+++ b/ink-trace-extension/src/extension.ts
@@ -1,37 +1,124 @@
 import * as vscode from 'vscode';
-import { InkDebugSession } from './inkDebugSession';
+import * as path from 'path';
+import * as child_process from 'child_process';
+import * as fs from 'fs';
 
 export function activate(context: vscode.ExtensionContext) {
+    console.log('Ink Trace Debugger extension activated');
+    vscode.window.showInformationMessage('Ink Trace Debugger: Activated');
+
     context.subscriptions.push(
         vscode.debug.registerDebugAdapterDescriptorFactory(
             'ink-trace',
-            new InkDebugAdapterDescriptorFactory()
-        ),
-        vscode.debug.registerDebugConfigurationProvider(
-            'ink-trace',
-            new InkDebugConfigurationProvider()
+            new InkDebugAdapterDescriptorFactory(context)
         )
+    );
+
+    context.subscriptions.push(
+        vscode.debug.registerDebugConfigurationProvider('ink-trace', {
+            provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined): vscode.ProviderResult<vscode.DebugConfiguration[]> {
+                return [
+                    {
+                        type: 'ink-trace',
+                        request: 'launch',
+                        name: 'Debug Ink Contract',
+                        program: '${file}',
+                        stopOnEntry: true
+                    }
+                ];
+            }
+        })
     );
 }
 
-export function deactivate() {}
-
-class InkDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
-    resolveDebugConfiguration(
-        _folder: vscode.WorkspaceFolder | undefined, 
-        config: vscode.DebugConfiguration
-    ): vscode.ProviderResult<vscode.DebugConfiguration> {
-        
-        if (!config.program) {
-            config.program = '${file}';
-        }
-        
-        return config;
-    }
+export function deactivate() {
+    console.log('Ink Trace Debugger extension deactivated');
 }
 
 class InkDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
-    createDebugAdapterDescriptor(session: vscode.DebugSession): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
-        return new vscode.DebugAdapterInlineImplementation(new InkDebugSession());
+    private context: vscode.ExtensionContext;
+
+    constructor(context: vscode.ExtensionContext) {
+        this.context = context;
+    }
+
+    private async checkPythonInstallation(): Promise<boolean> {
+        console.log('Checking Python installation...');
+        const isWindows = process.platform === 'win32';
+        const commands = isWindows ? ['python --version', 'py --version'] : ['python3 --version'];
+
+        for (const command of commands) {
+            try {
+                const result = await new Promise<boolean>((resolve) => {
+                    child_process.exec(command, (error) => {
+                        resolve(error === null);
+                    });
+                });
+                if (result) {
+                    console.log(`Python found via: ${command}`);
+                    return true;
+                }
+            } catch (e) {
+                console.warn(`Command failed: ${command}`, e);
+            }
+        }
+
+        return false;
+    }
+
+    async createDebugAdapterDescriptor(
+        session: vscode.DebugSession
+    ): Promise<vscode.DebugAdapterDescriptor> {
+        console.log('Creating debug adapter descriptor');
+        console.log('Configuration:', JSON.stringify(session.configuration, null, 2));
+
+        const hasPython = await this.checkPythonInstallation();
+        if (!hasPython) {
+            const message = "Python 3 not found. Please install Python and add it to PATH.";
+            vscode.window.showErrorMessage(message);
+            throw new Error(message);
+        }
+
+        const serverScript = path.join(this.context.extensionPath, 'ink-dap-server', 'main.py');
+        console.log(`Looking for server script at: ${serverScript}`);
+
+        if (!fs.existsSync(serverScript)) {
+            const message = `DAP server not found at: ${serverScript}`;
+            console.error(message);
+            vscode.window.showErrorMessage(message);
+            throw new Error(message);
+        }
+
+        console.log('Server script found');
+
+        try {
+            const pythonExecutable = process.platform === 'win32' ? 'python' : 'python3';
+            const options: vscode.DebugAdapterExecutableOptions = {
+                cwd: path.dirname(serverScript),
+                env: {
+                    ...process.env,
+                    RUST_LOG: "debug"
+                }
+            };
+
+            console.log('Launching DAP server with:', {
+                python: pythonExecutable,
+                script: serverScript,
+                args: session.configuration,
+                cwd: options.cwd
+            });
+
+            vscode.window.showInformationMessage('Starting Ink Debug Adapter...');
+            return new vscode.DebugAdapterExecutable(
+                pythonExecutable,
+                [serverScript],
+                options
+            );
+        } catch (error) {
+            const message = `Failed to launch DAP server: ${error}`;
+            console.error('Error:', error);
+            vscode.window.showErrorMessage(message);
+            throw error;
+        }
     }
 }


### PR DESCRIPTION
This PR adds support for launching the Python-based DAP server (`main.py`) from the VS Code extension.

✅ Cross-platform (uses `context.extensionPath`)  
✅ Python detection (`python` / `python3` / `py`)  
✅ Launches via `stdin/stdout` using DebugAdapterExecutable  
✅ Console logs for debugging  
✅ Fully tested with F5 in Extension Development Host
